### PR TITLE
Make 2 failing specs agnostic of git version, allow one to run on older versions of git

### DIFF
--- a/support/git-functions.sh
+++ b/support/git-functions.sh
@@ -13,6 +13,20 @@ check_tag_exists() {
   fi;
 }
 
+current_git_version() {
+  local git_version="`git --version`"
+  local newline=$'\n'
+  regex=".*git version ([0-9\.]+).*$"
+
+  if [[ $git_version =~ $regex ]]; then
+    local full_version=$BASH_REMATCH
+    local version_number="${BASH_REMATCH[1]}"
+    echo "$version_number"
+  else
+    echo "Error - Unable to determine git version."
+  fi;
+}
+
 ensure_git_directory() {
   if [[ ! -d  '.git' ]]; then
     echo "Error - Not a git repository please run from the base of your git repo." >&2

--- a/test/integration/releaseable-deployed-test.sh
+++ b/test/integration/releaseable-deployed-test.sh
@@ -6,11 +6,6 @@
 rup() { ./bin/git-release-deployed $@; }
 sandbox_rup() { /bin/bash ../bin/git-release-deployed $@; }
 
-usage_head="++ /bin/bash ../bin/git-release-deployed
-Required parameter: Please enter the deploy tag released.
-
-usage : git-release-deployed $(arg_for $ARG_DEPLOYED_TAG '<deployed_tag>') [$(arg_for $ARG_RELEASE_PREFIX '<prefix>')] [$(arg_for $ARG_START '<start>')] [$(arg_for $ARG_FINISH '<finish>')]"
-
 describe "git-release-deployed - integration"
 
 after() {
@@ -30,8 +25,11 @@ it_will_fail_with_no_deployed_tag() {
 it_will_display_help_text_on_fail() {
   generate_git_repo
 
-  local output=$(sandbox_rup 2>&1 | head -n 4 2>&1)
-  test "$output" = "$usage_head"
+  # Ignore first "++ /bin/bash ../bin/git-release-deployed" line, as in git >= 1.8.5 it is "++/bin/bash ..."
+  local output=$(sandbox_rup 2>&1 | head -n 4 2>&1 | tail -n 3 2>&1)
+  test "$output" = "Required parameter: Please enter the deploy tag released.
+
+usage : git-release-deployed $(arg_for $ARG_DEPLOYED_TAG '<deployed_tag>') [$(arg_for $ARG_RELEASE_PREFIX '<prefix>')] [$(arg_for $ARG_START '<start>')] [$(arg_for $ARG_FINISH '<finish>')]"
 }
 
 it_will_display_error_when_no_git_directory_exists() {

--- a/test/integration/releaseable-test.sh
+++ b/test/integration/releaseable-test.sh
@@ -6,12 +6,6 @@
 rup() { ./bin/git-release $@; }
 sandbox_rup() { /bin/bash ../bin/git-release $@; }
 
-usage_head="++ /bin/bash ../bin/git-release
-incorrect versioning type: ''
-Please set to one of 'major', 'minor' or 'patch'
-
-usage : git-release $(arg_for $ARG_VERSION '<version>') [$(arg_for $ARG_RELEASE_PREFIX '<prefix>')] [$(arg_for $ARG_START '<start>')] [$(arg_for $ARG_FINISH '<finish>')]"
-
 describe "git-release - integration"
 
 after() {
@@ -29,8 +23,13 @@ it_will_fail_with_no_versioning_type() {
 it_will_display_help_text_on_fail() {
   generate_git_repo
 
-  local output=$(sandbox_rup 2>&1 | head -n 5 2>&1)
-  test "$output" = "$usage_head"
+  # Ignore first "++ /bin/bash ../bin/git-release-deployed" line, as in git >= 1.8.5 it is "++/bin/bash ..."
+
+  local output=$(sandbox_rup 2>&1 | head -n 5 2>&1 | tail -n 4 2>&1)
+  test "$output" = "incorrect versioning type: ''
+Please set to one of 'major', 'minor' or 'patch'
+
+usage : git-release $(arg_for $ARG_VERSION '<version>') [$(arg_for $ARG_RELEASE_PREFIX '<prefix>')] [$(arg_for $ARG_START '<start>')] [$(arg_for $ARG_FINISH '<finish>')]"
 }
 
 it_will_display_error_when_no_git_directory_exists() {

--- a/test/unit/git-functions-test.sh
+++ b/test/unit/git-functions-test.sh
@@ -74,13 +74,33 @@ it_fails_on_ensure_git_is_clean_when_dirty(){
   touch 'AnyOldFile'
   should_fail $(ensure_git_is_clean)
 
-  test "$(ensure_git_is_clean)" = "Error - Current branch is in a dirty state, please commit your changes first.
+  local git_version=$(current_git_version)
+  local updated_git_output_version="1.8.5.3"
+
+  # 1.8.5.3 + git version has hash prefix on output lines, < (1.8.4.3) doesn't
+  if (( $(echo "$git_version $updated_git_output_version" | awk '{print ($1 < $2)}') )); then
+
+    local expected_git_output="Error - Current branch is in a dirty state, please commit your changes first.
 # On branch master
 # Untracked files:
 #   (use \"git add <file>...\" to include in what will be committed)
 #
 #"$'\t'"AnyOldFile
+nothing added to commit but untracked files present (use \"git add\" to track)";
+
+  else
+
+    local expected_git_output="Error - Current branch is in a dirty state, please commit your changes first.
+On branch master
+Untracked files:
+  (use \"git add <file>...\" to include in what will be committed)
+
+"$'\t'"AnyOldFile
+
 nothing added to commit but untracked files present (use \"git add\" to track)"
+  fi
+
+  test "$(ensure_git_is_clean)" = "${expected_git_output}"
 }
 
 it_passes_on_ensure_git_is_clean_when_clean(){


### PR DESCRIPTION
Allow multiple versions of git to run the tests.

Issues with 1.8.4.3 -> 1.8.5.3+ where the output has changed.

2 specs made to not care on the output diff, one to display the difference.
