### PR TITLE
Refactor changelog function to break up tagging and sorting from the git  log title generation

### DIFF
--- a/test/integration/releaseable-deployed-test.sh
+++ b/test/integration/releaseable-deployed-test.sh
@@ -146,8 +146,10 @@ it_will_genereate_a_new_deploy_tag_for_next_release_with_defaults() {
 || Release: 1.0.6
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 latest commit message to 1.0.6
 The last deployed release
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -158,8 +160,10 @@ $(changelog_footer)"
 || Release: 1.0.6
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 latest commit message to 1.0.6
 The last deployed release
+
 $(changelog_divider)
 $(changelog_footer)"
 }
@@ -184,10 +188,12 @@ it_will_generate_a_deploy_changelog_for_a_set_starting_point() {
 || Release: 1.0.6
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 latest commit message to 1.0.6
 [Any Old] Message for 1.0.5
 commit message for 1.0.4
 Initial Commit
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -197,8 +203,10 @@ $(changelog_footer)"
 || Release: 1.0.6
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 latest commit message to 1.0.6
 [Any Old] Message for 1.0.5
+
 $(changelog_divider)
 $(changelog_footer)"
 }
@@ -223,8 +231,10 @@ it_will_generate_a_deploy_changelog_for_a_set_range_with_start_and_end() {
 || Release: 1.0.6
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 [Any Old] Message for 1.0.5
 commit message for 1.0.4
+
 $(changelog_divider)
 $(changelog_footer)"
 }
@@ -287,6 +297,7 @@ Fixing the login but no tag displayed."
 || Release: 0.0.1
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 Features:
   This is a pull request merging a feature across multiple
 lines and continuing
@@ -298,6 +309,7 @@ Bugs:
   Login screen broken in firefox
 
 Fixing the login but no tag displayed.
+
 $(changelog_divider)
 $(changelog_footer)"
 }
@@ -322,8 +334,10 @@ it_will_append_to_a_deploy_changelog_optionally(){
 || Release: 1.0.7
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 commit message for 1.0.7
 Initial Commit
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -339,16 +353,20 @@ test "$(cat CHANGELOG)" = "$(changelog_divider)
 || Release: 1.0.8
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 Merge tag 'deployed/releases/v1.0.7' into HEAD
 [Any Old] Message for 1.0.8
 Release deployed : releases/v1.0.7
+
 $(changelog_divider)
 $(changelog_divider)
 || Release: 1.0.7
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 commit message for 1.0.7
 Initial Commit
+
 $(changelog_divider)
 $(changelog_footer)"
 }

--- a/test/integration/releaseable-test.sh
+++ b/test/integration/releaseable-test.sh
@@ -127,7 +127,9 @@ it_will_generate_files_by_default_from_last_tag_to_head() {
 || Release: 2.0.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 latest commit message to 1.0.6
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -156,9 +158,11 @@ it_will_generate_a_changelog_for_a_set_starting_point() {
 || Release: 1.0.7
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 latest commit message to 1.0.6
 Lots of changes in this commit for random commit 2
 [Any Old] Message for 1.0.5
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -189,9 +193,11 @@ it_will_generate_a_changelog_for_a_set_range_with_start_and_end() {
 || Release: 1.1.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 latest commit message to 1.0.6
 Lots of changes in this commit for random commit 2
 [Any Old] Message for 1.0.5
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -222,7 +228,9 @@ it_will_generate_files_with_optional_names() {
 || Release: 2.0.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 latest commit message to 1.0.6
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -265,6 +273,7 @@ Fixing the login but no tag displayed."
 || Release: 0.1.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 Features:
   This is a pull request merging a feature across multiple
 lines and continuing
@@ -276,6 +285,7 @@ Bugs:
   logout screen
 
 Fixing the login but no tag displayed.
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -302,8 +312,10 @@ it_will_overwrite_a_changelog_file_by_default() {
 || Release: 1.1.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 [Any Old] Message for 1.0.5
 Commit for last released start point 1.0.4
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -315,8 +327,10 @@ $(changelog_footer)"
 || Release: 2.0.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 latest commit message to 1.0.6
 [Any Old] Message for 1.0.5
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -341,7 +355,9 @@ it_will_append_to_a_changelog_optionally(){
 || Release: 1.1.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 [Any Old] Message for 1.0.5
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -353,13 +369,17 @@ $(changelog_footer)"
 || Release: 2.0.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 Release : releases/v1.1.0
+
 $(changelog_divider)
 $(changelog_divider)
 || Release: 1.1.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 [Any Old] Message for 1.0.5
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -377,7 +397,9 @@ it_will_generate_in_an_opinionated_fashion(){
 || Release: 0.1.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 Initial Commit
+
 $(changelog_divider)
 $(changelog_footer)"
 
@@ -389,13 +411,17 @@ $(changelog_footer)"
 || Release: 1.0.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 Release : releases/v0.1.0
+
 $(changelog_divider)
 $(changelog_divider)
 || Release: 0.1.0
 || Released on $(get_current_release_date)
 $(changelog_divider)
+
 Initial Commit
+
 $(changelog_divider)
 $(changelog_footer)"
 


### PR DESCRIPTION
We're going to need to add custom prefixes (urls) on a per line basis. 

So now I want the ability to easily append items on a line by line, however, the generate text was performing 2 actions.

To get this to work, i needed padding around the unescaped lines. 
