### PR TITLE
Add additional grouping headers for changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ Generation is based on all git commits between a start and end point ordered by 
 
 Developers that follow feature branches can pass an optional parameter to generate the changelog only on the pull requests merged in (the 'epics') providing a much cleaner list of content.
 
-Tagged content of the changelog is limited at the moment, I'm looking at ways to make this dynamic. But right now, any commit with the following prefixes (ignoring spaces and case) will group the commits in the `CHANGELOG` and present under ordered headings:
+Tagged content of the changelog is limited at the moment, I'm looking at ways to make this dynamic. But right now, any commit with the following prefixes (ignoring spaces and case) will group the commits in the `CHANGELOG` and present under ordered (case insensitive) headings:
 
-   * `[feature]`
-   * `[security]`
-   * `[bug]`
+   * `[Security]`
+   * `[Bug]` or `[Bugs]`
+   * `[UI Enhancement]` or `[UI Enhancements]`
+   * `[Engineering Enhancement]` or `[Engineering Enhancements]`
+   * `[Feature]` or `[Features]`
 
 ## Deploy
 

--- a/support/changelog-functions.sh
+++ b/support/changelog-functions.sh
@@ -118,12 +118,31 @@ group_and_sort_changelog_lines() {
   local feature_tag_lines=""
   local bug_tag_lines=""
   local security_tag_lines=""
+  local defect_lines=""
+  local ui_enhancement_lines=""
+  local engineering_enhancement_lines=""
+
   local general_release_lines=""
+
+# Bugs:
+#  < Stuff that we've found >
+
+# QC Defects:
+#  < Stuff that they've found >
+
+# UI Enhancements:
+#  < Stuff we made better that you can see >
+
+# Engineering enhancements:
+#  < Stuff we made better that you can't see >
+
+# Features:
+#  < New things >
 
   local newline=$'\n'
 
   while read -r line; do
-    local tag_regex="^\s*\[(features?|bugs?|security)\]\s*(.*)\s*$"
+    local tag_regex="^\s*\[(features?|bugs?|security|qc defects?|defects?|ui enhancements?|engineering enhancements?)\]\s*(.*)\s*$"
     if [[ $line =~ $tag_regex ]]; then
       #Tagged entry
       local full_tag=$BASH_REMATCH
@@ -135,6 +154,12 @@ group_and_sort_changelog_lines() {
 
       #Sort matching tags
       case "$tag_type" in
+          [qQ][cC][\ ][dD][eE][fF][eE][cC][tT] | [qQ][cC][\ ][dD][eE][fF][eE][cC][tT][sS] | [dD][eE][fF][eE][cC][tT] | [dD][eE][fF][eE][cC][tT][sS] )
+              defect_lines+="$tag_content";;
+          [uU][iI][\ ][eE][nN][hH][aA][nN][cC][eE][mM][eE][nN][tT] | [uU][iI][\ ][eE][nN][hH][aA][nN][cC][eE][mM][eE][nN][tT][sS] )
+              ui_enhancement_lines+="$tag_content";;
+          [eE][nN][gG][iI][nN][eE][eE][rR][iI][nN][gG][\ ][eE][nN][hH][aA][nN][cC][eE][mM][eE][nN][tT] | [eE][nN][gG][iI][nN][eE][eE][rR][iI][nN][gG][\ ][eE][nN][hH][aA][nN][cC][eE][mM][eE][nN][tT][sS] )
+              engineering_enhancement_lines+="$tag_content";;
           [fF][eE][aA][tT][uU][rR][eE] | [fF][eE][aA][tT][uU][rR][eE][sS] )
               feature_tag_lines+="${tag_content}";;
           [bB][uU][gG] | [bB][uU][gG][sS] )
@@ -151,11 +176,7 @@ group_and_sort_changelog_lines() {
   done <<< "$1";
 
   # Print out tagged content in order
-  if [[ $feature_tag_lines != '' ]]; then
-    echo "Features:
-${feature_tag_lines}"
-  fi;
-  if [[ $security_tag_lines != '' ]]; then
+    if [[ $security_tag_lines != '' ]]; then
     echo "Security:
 ${security_tag_lines}"
   fi;
@@ -163,6 +184,23 @@ ${security_tag_lines}"
     echo "Bugs:
 ${bug_tag_lines}"
   fi;
+  if [[ $defect_lines != '' ]]; then
+    echo "Defects:
+${defect_lines}"
+  fi;
+  if [[ $ui_enhancement_lines != '' ]]; then
+    echo "UI Enhancements:
+${ui_enhancement_lines}"
+  fi;
+  if [[ $engineering_enhancement_lines != '' ]]; then
+    echo "Engineering Enhancements:
+${engineering_enhancement_lines}"
+  fi;
+  if [[ $feature_tag_lines != '' ]]; then
+    echo "Features:
+${feature_tag_lines}"
+  fi;
+
   echo "$general_release_lines${newline}"
 
   #Return previous setup for bash

--- a/test/integration/releaseable-deployed-test.sh
+++ b/test/integration/releaseable-deployed-test.sh
@@ -298,15 +298,15 @@ Fixing the login but no tag displayed."
 || Released on $(get_current_release_date)
 $(changelog_divider)
 
-Features:
-  This is a pull request merging a feature across multiple
-lines and continuing
-
 Security:
   Commit fixing the modal with security flaw
 
 Bugs:
   Login screen broken in firefox
+
+Features:
+  This is a pull request merging a feature across multiple
+lines and continuing
 
 Fixing the login but no tag displayed.
 
@@ -346,13 +346,13 @@ Fixing the login but no tag displayed."
 || Released on $(get_current_release_date)
 $(changelog_divider)
 
-Features:
-  This is a pull request merging a feature across multiple
-lines and continuing - https://github.com/organisation/repo-name/pull/722
-
 Bugs:
   Fix cookie storing sensitive data - https://github.com/organisation/repo-name/pull/685
   logout screen - https://github.com/organisation/repo-name/pull/705
+
+Features:
+  This is a pull request merging a feature across multiple
+lines and continuing - https://github.com/organisation/repo-name/pull/722
 
 Fixing the login but no tag displayed. - https://github.com/organisation/repo-name/pull/714
 
@@ -405,11 +405,12 @@ it_will_append_to_a_deploy_changelog_optionally(){
 
   generate_sandbox_tags tags[@] commit_messages[@]
 
+  local first_release_time=$(get_current_release_date)
   sandbox_rup $(arg_for $ARG_DEPLOYED_TAG 'releases/v1.0.7')
 
   test "$(cat CHANGELOG)" = "$(changelog_divider)
 || Release: 1.0.7
-|| Released on $(get_current_release_date)
+|| Released on ${first_release_time}
 $(changelog_divider)
 
 commit message for 1.0.7
@@ -424,11 +425,12 @@ $(changelog_footer)"
   git tag -f releases/v1.0.8
   git checkout master
 
+  local second_release_time=$(get_current_release_date)
   sandbox_rup $(arg_for $ARG_DEPLOYED_TAG 'releases/v1.0.8') $(arg_for $ARG_APPEND)
 
 test "$(cat CHANGELOG)" = "$(changelog_divider)
 || Release: 1.0.8
-|| Released on $(get_current_release_date)
+|| Released on ${second_release_time}
 $(changelog_divider)
 
 Merge tag 'deployed/releases/v1.0.7' into HEAD
@@ -438,7 +440,7 @@ Release deployed : releases/v1.0.7
 $(changelog_divider)
 $(changelog_divider)
 || Release: 1.0.7
-|| Released on $(get_current_release_date)
+|| Released on ${first_release_time}
 $(changelog_divider)
 
 commit message for 1.0.7

--- a/test/integration/releaseable-test.sh
+++ b/test/integration/releaseable-test.sh
@@ -308,15 +308,15 @@ Fixing the login but no tag displayed."
 || Released on $(get_current_release_date)
 $(changelog_divider)
 
-Features:
-  This is a pull request merging a feature across multiple
-lines and continuing
-
 Security:
   Commit fixing the modal with security flaw
 
 Bugs:
   logout screen
+
+Features:
+  This is a pull request merging a feature across multiple
+lines and continuing
 
 Fixing the login but no tag displayed.
 
@@ -358,13 +358,13 @@ Fixing the login but no tag displayed."
 || Released on $(get_current_release_date)
 $(changelog_divider)
 
-Features:
-  This is a pull request merging a feature across multiple
-lines and continuing - https://github.com/organisation/repo-name/pull/722
-
 Bugs:
   Fix cookie storing sensitive data - https://github.com/organisation/repo-name/pull/685
   logout screen - https://github.com/organisation/repo-name/pull/705
+
+Features:
+  This is a pull request merging a feature across multiple
+lines and continuing - https://github.com/organisation/repo-name/pull/722
 
 Fixing the login but no tag displayed. - https://github.com/organisation/repo-name/pull/714
 

--- a/test/unit/changelog-functions-test.sh
+++ b/test/unit/changelog-functions-test.sh
@@ -197,13 +197,13 @@ it_uses_group_and_sort_changelog_lines_to_return_titles_grouped_by_tags() {
 
   output=$(group_and_sort_changelog_lines "$commit_messages")
 
-  test "$output" = "Features:
-  OMG. I had time to write something of use
-  Its so exciting writing useful things!!
-
-Bugs:
+  test "$output" = "Bugs:
   Argh, I fixed a bug here
   What comes up, must come down
+
+Features:
+  OMG. I had time to write something of use
+  Its so exciting writing useful things!!
 
 Start of the project
 Some random tweak fix"
@@ -212,16 +212,40 @@ Some random tweak fix"
 it_uses_group_and_sort_changelog_lines_to_return_titles_grouped_by_tags_case_insensitive() {
   local commit_messages="[Bug] Start of the project
     [BUGS]   Argh, I fixed a bug here
-    [fEaTuRes]     OMG. I had time to write something of use"
+    [EngineerIng EnhanceMENTs] I made the developers future life better
+    [fEaTuRes]     OMG. I had time to write something of use
+    [EngineerIng EnhanceMENT] Releasing became less of a stressful episode of despair
+    [Qc Defect] [QC2487] Some defect to fix
+    [UI EnHanceMent] I changed a pixel
+    [DefecT] [QC2930] A single pain
+    Untagged Commit
+    [UI EnHanceMentS] I changed the colour
+    [QC DEFECTS] Another defect"
 
   output=$(group_and_sort_changelog_lines "$commit_messages")
 
-  test "$output" = "Features:
+  test "$output" = "Bugs:
+  Start of the project
+  Argh, I fixed a bug here
+
+Defects:
+  [QC2487] Some defect to fix
+  [QC2930] A single pain
+  Another defect
+
+UI Enhancements:
+  I changed a pixel
+  I changed the colour
+
+Engineering Enhancements:
+  I made the developers future life better
+  Releasing became less of a stressful episode of despair
+
+Features:
   OMG. I had time to write something of use
 
-Bugs:
-  Start of the project
-  Argh, I fixed a bug here"
+Untagged Commit"
+
 }
 
 it_uses_group_and_sort_changelog_lines_to_return_titles_grouped_by_tags_with_multiple_brackets() {
@@ -230,11 +254,12 @@ it_uses_group_and_sort_changelog_lines_to_return_titles_grouped_by_tags_with_mul
 
   output=$(group_and_sort_changelog_lines "$commit_messages")
 
-  test "$output" = "Features:
-  [Additonal Tag one] Another referenced feature
+  test "$output" = "Bugs:
+  [QC Some Reference][More Custom References] Fixed the tagged bugs
 
-Bugs:
-  [QC Some Reference][More Custom References] Fixed the tagged bugs"
+Features:
+  [Additonal Tag one] Another referenced feature"
+
 }
 
 #generate_changelog_content
@@ -381,15 +406,15 @@ Fixing the login but no tag displayed."
 || Released on $(get_current_release_date)
 $(changelog_divider)
 
-Features:
-  This is a pull request merging a feature across multiple
-lines and continuing
-
 Security:
   Commit fixing the modal with security flaw
 
 Bugs:
   Login field length
+
+Features:
+  This is a pull request merging a feature across multiple
+lines and continuing
 
 Fixing the login but no tag displayed.
 
@@ -420,11 +445,11 @@ it_uses_generate_changelog_content_to_list_pull_requests_with_urls(){
 || Released on $(get_current_release_date)
 $(changelog_divider)
 
-Features:
-  This is yet another pull request - https://github.com/organisation/repo-name/pull/722
-
 Bugs:
   Login field length - https://github.com/organisation/repo-name/pull/705
+
+Features:
+  This is yet another pull request - https://github.com/organisation/repo-name/pull/722
 
 $(changelog_divider)"
 }


### PR DESCRIPTION
Updated headers and ordering: 
- `[Security]`
- `[Bug]` or `[Bugs]`
- `[UI Enhancement]` or `[UI Enhancements]`
- `[Engineering Enhancement]` or `[Engineering Enhancements]`
- `[Feature]` or `[Features]`
